### PR TITLE
Make the docker container smaller and add documentation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,7 @@ RUN CGO_ENABLED=0 GOOS=linux go install -a -ldflags '-extldflags "-static"' .
 
 FROM scratch
 COPY --from=builder /go/bin/squid-exporter /usr/local/bin/squid-exporter
+
+EXPOSE 9301
+
 ENTRYPOINT ["/usr/local/bin/squid-exporter"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang
+FROM golang:alpine as builder
 
 WORKDIR /go/src/github.com/boynux/squid-exporter
 COPY . .
@@ -6,6 +6,6 @@ COPY . .
 # Compile the binary statically, so it can be run without libraries.
 RUN CGO_ENABLED=0 GOOS=linux go install -a -ldflags '-extldflags "-static"' .
 
-FROM alpine
-COPY --from=0 /go/bin/squid-exporter /usr/local/bin/squid-exporter
+FROM scratch
+COPY --from=builder /go/bin/squid-exporter /usr/local/bin/squid-exporter
 ENTRYPOINT ["/usr/local/bin/squid-exporter"]

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Basic setup assuming Squid is running on the same machine:
 
 Setup with Squid running on a different host
 
-    docker run -p 9301:9301 -d boynux/squid-exporter -squid-hostname "192.168.0.2" -squid-port 3128 -listen-port "0.0.0.0"
+    docker run -p 9301:9301 -d boynux/squid-exporter -squid-hostname "192.168.0.2" -squid-port 3128 -listen-address "0.0.0.0"
 
 Features:
 ---------

--- a/README.md
+++ b/README.md
@@ -25,6 +25,16 @@ To get all the parameteres
     squid-exprter -help
 
 
+Usage with docker:
+------
+Basic setup assuming Squid is running on the same machine:
+
+    docker run --net=host -d boynux/squid-exporter
+
+Setup with Squid running on a different host
+
+    docker run -p 9301:9301 -d boynux/squid-exporter -squid-hostname "192.168.0.2" -squid-port 3128 -listen-port "0.0.0.0"
+
 Features:
 ---------
 


### PR DESCRIPTION
The docker container works fine without the unnecessary added bloat of alpine, and can be built fine from scratch, and run in an empty container. This change saves a few megabytes of disk usage and speeds things up slightly.

I also made the code more readable by adding as builder to make it more clear that we are using a multi container build.