### PR TITLE
Populate /etc/nsswitch.conf so hosts file is used

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,9 @@ RUN CGO_ENABLED=0 GOOS=linux go install -a -ldflags '-extldflags "-s -w -static"
 FROM scratch
 COPY --from=builder /go/bin/squid-exporter /usr/local/bin/squid-exporter
 
+# Allow /etc/hosts to be used for DNS
+COPY --from=builder /etc/nsswitch.conf /etc/nsswitch.conf
+
 EXPOSE 9301
 
 ENTRYPOINT ["/usr/local/bin/squid-exporter"]


### PR DESCRIPTION
Golang doesn't use /etc/hosts unless told by /etc/nsswitch.conf. See https://github.com/golang/go/issues/22846 for details.

We are running squid and squid-exporter in the same pod, and using the pod name as the hostname doesn't work. We want the hostname rather than localhost so we get unique names per pod. Adding `/etc/nsswitch.conf` allows the hosts file to be read, which allows the pod name to be resolved.

I suspect anyone using docker to manage /etc/hosts would hit this as well.