### PR TITLE
Bump Go version to 1.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: go
 
+go:
+- 1.13.x
+
 deploy:
   provider: releases
   api_key: 

--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,9 @@ VERSION ?= $(shell cat VERSION)
 REVISION = $(shell git rev-parse HEAD)
 BRANCH = $(shell git rev-parse --abbrev-ref HEAD)
 LDFLAGS = -extldflags "-s -w -static" \
-		  -X github.com/boynux/squid-exporter/vendor/github.com/prometheus/common/version.Version=$(VERSION) \
-		  -X github.com/boynux/squid-exporter/vendor/github.com/prometheus/common/version.Revision=$(REVISION) \
-		  -X github.com/boynux/squid-exporter/vendor/github.com/prometheus/common/version.Branch=$(BRANCH)
+		  -X github.com/prometheus/common/version.Version=$(VERSION) \
+		  -X github.com/prometheus/common/version.Revision=$(REVISION) \
+		  -X github.com/prometheus/common/version.Branch=$(BRANCH)
 
 $(EXE): $(SRC)
 	CGO_ENABLED=0 GOOS=linux go build -a -ldflags '$(LDFLAGS)' -o $(EXE) .

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,8 @@
 module github.com/boynux/squid-exporter
 
-go 1.12
+go 1.13
 
 require (
-	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
-	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/prometheus/client_golang v1.1.0
 	github.com/prometheus/common v0.6.0
 )

--- a/go.sum
+++ b/go.sum
@@ -4,7 +4,6 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/boynux/squid-exporter v0.0.0-20171021195124-6dcf7c016995/go.mod h1:VSICGV4XC8I2AsWmKFRAxYOYNc/GxKAVkARON6FaD68=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=


### PR DESCRIPTION
This change updates the Go version in go.mod and travis configuration,
and updates build info variables to not point to explicitly vendor'd
paths.

Resolves #35 
