### PR TITLE
Add optional squid process metrics

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -24,6 +24,7 @@ const (
 	squidPortKey                = "SQUID_PORT"
 	squidLoginKey               = "SQUID_LOGIN"
 	squidPasswordKey            = "SQUID_PASSWORD"
+	squidPidfile                = "SQUID_PIDFILE"
 )
 
 var (
@@ -46,6 +47,7 @@ type Config struct {
 	SquidPort     int
 	Login         string
 	Password      string
+	Pidfile       string
 }
 
 /*NewConfig creates a new config object from command line args */
@@ -66,6 +68,8 @@ func NewConfig() *Config {
 
 	flag.StringVar(&c.Login, "squid-login", loadEnvStringVar(squidLoginKey, ""), "Login to squid service")
 	flag.StringVar(&c.Password, "squid-password", loadEnvStringVar(squidPasswordKey, ""), "Password to squid service")
+
+	flag.StringVar(&c.Pidfile, "squid-pidfile", loadEnvStringVar(squidPidfile, ""), "Optional path to the squid PID file for additional metrics")
 
 	VersionFlag = flag.Bool("version", false, "Print the version and exit")
 


### PR DESCRIPTION
This change adds the `-squid-pidfile` option / `SQUID_PIDFILE`
environment variable to pass the squid PID file to squid_exporter. If
the exporter has adequate permissions to read the `/proc` entry for the
squid process (e.g. by running under the same uid), the following
additional metrics are exported:

```
squid_process_cpu_seconds_total
squid_process_max_fds
squid_process_open_fds
squid_process_resident_memory_bytes
squid_process_start_time_seconds
squid_process_virtual_memory_bytes
squid_process_virtual_memory_max_bytes
```