### PR TITLE
Append Authorization header in addition to Proxy-Authorization

### DIFF
--- a/collector/client.go
+++ b/collector/client.go
@@ -168,11 +168,13 @@ func get(conn net.Conn, path string, basicAuthString string, headers []string) (
 
 	if len(basicAuthString) > 0 {
 		rBody = append(rBody, "Proxy-Authorization: Basic "+basicAuthString)
+		rBody = append(rBody, "Authorization: Basic "+basicAuthString)
 	}
 	rBody = append(rBody, "Accept: */*", "\r\n")
 	request := strings.Join(rBody, "\r\n")
 
-	fmt.Fprintf(conn, request)
+	fmt.Fprint(conn, request)
+
 	return http.ReadResponse(bufio.NewReader(conn), nil)
 }
 


### PR DESCRIPTION
This PR adds a new HTTP request header to requests to Squid Proxy.
The new header is an HTTP basic authentication header (`Authorization: Basic ...`).

The reason is that in Squid 5.5 (RockyLinux 9) the existing `Proxy-Authorization` header does not work.

Signed-off-by: Dmitrii Ermakov <dmitrii.ermakov@maxiv.lu.se>