### PR TITLE
Change service_metrics metadata from Counter to Gauge

### DIFF
--- a/collector/metrics.go
+++ b/collector/metrics.go
@@ -108,7 +108,7 @@ func (e *Exporter) Collect(c chan<- prometheus.Metric) {
 		if err == nil {
 			for i := range insts {
 				if d, ok := serviceTimes[insts[i].Key]; ok {
-					c <- prometheus.MustNewConstMetric(d, prometheus.CounterValue, insts[i].Value, e.labels.Values...)
+					c <- prometheus.MustNewConstMetric(d, prometheus.GaugeValue, insts[i].Value, e.labels.Values...)
 				}
 			}
 		} else {


### PR DESCRIPTION
This PR is solving the issue opened in  https://github.com/boynux/squid-exporter/issues/67.

Service Time metrics are set as Gauge in the metadata instead of Counter because they are non monotonic and can decrease in value.