### PR TITLE
Improve security for Dockerfile - non-root image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ COPY . .
 # Compile the binary statically, so it can be run without libraries.
 RUN CGO_ENABLED=0 GOOS=linux go install -a -ldflags '-extldflags "-s -w -static"' .
 
-FROM scratch
+FROM gcr.io/distroless/static:nonroot
 COPY --from=builder /go/bin/squid-exporter /usr/local/bin/squid-exporter
 
 # Allow /etc/hosts to be used for DNS


### PR DESCRIPTION
Hi, I want to integrate your image into a k8s cluster, but to respect our security policy, the process must not run on the root user.