### PR TITLE
Automatically build release binaries for multiple architectures using github actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
           - arch: arm
             armver: 7
     env:
-      arch_name: ${{ join((matrix.arch, matrix.armver), 'v' }}
+      arch_name: ${{ matrix.arch }}${{ matrix.arch == 'arm' && 'v' || '' }}${{ matrix.armver }}
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,7 @@ jobs:
             armver: 7
     env:
       arch_name: ${{ matrix.arch }}${{ matrix.arch == 'arm' && 'v' || '' }}${{ matrix.armver }}
+    name: Build for ${{ env.arch_name }}
 
     steps:
     - name: Checkout repository
@@ -61,8 +62,8 @@ jobs:
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          asset_name: squid-exporter
-          file: bin/squid-exporter
+          file: bin/squid-exporter-*
+          file_glob: true
           tag: unstable
           overwrite: true
           body: "pre-release"
@@ -73,8 +74,8 @@ jobs:
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: bin/squid-exporter
-          asset_name: squid-exporter
+          file: bin/squid-exporter-*
+          file_glob: true
           tag: ${{ github.ref }}
           overwrite: true
           body: "Stable release"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,11 +14,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: [386, amd64, arm, arm64]
+        arch_name: [386, amd64, armv6, armv7, arm64]
         include:
-          - arch: arm
+          - arch: ${{ matrix.arch_name }}
+          - arch_name: armv6
+            arch: arm
             armver: 6
-          - arch: arm
+          - arch_name: armv7
+            arch: arm
             armver: 7
 
     steps:
@@ -31,19 +34,14 @@ jobs:
         # Path to the go.mod or go.work file.
         go-version-file: go.mod
 
-    - name: Build ${{ matrix.arch }} binary
+    - name: Build ${{ matrix.arch_name }} binary
       run: make build
       env:
         GOARCH: ${{ matrix.arch }}
         GOARM: ${{ matrix.armver }}
 
-    - name: Rename ${{ matrix.arch }} binary
-      if: ${{ matrix.arch != 'arm' }}
-      run: mv bin/squid-exporter bin/squid-exporter-linux-${{ matrix.arch }}
-
-    - name: Rename ${{ matrix.arch }}v${{ matrix.armver }} binary
-      if: ${{matrix.arch == 'arm' }}
-      run: mv bin/squid-exporter bin/squid-exporter-linux-${{ matrix.arch }}v${{ matrix.armver }}
+    - name: Rename ${{ matrix.arch_name }} binary
+      run: mv bin/squid-exporter bin/squid-exporter-linux-${{ matrix.arch_name }}
 
     - name: Upload binary
       uses: actions/upload-artifact@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
             armver: 7
     env:
       arch_name: ${{ matrix.arch }}${{ matrix.arch == 'arm' && 'v' || '' }}${{ matrix.armver }}
-    name: Build for ${{ env.arch_name }}
+    name: Build for ${{ matrix.arch }}${{ matrix.arch == 'arm' && 'v' || '' }}${{ matrix.armver }}
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,24 +10,46 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [386, amd64, arm, arm64]
+        include:
+          - arch: arm
+            armver: 6
+          - arch: arm
+            armver: 7
 
     steps:
-    - uses: actions/checkout@v3
+    - name: Checkout repository
+      uses: actions/checkout@v4
 
     - name: Setup Go environment
-      uses: actions/setup-go@v4.0.0
+      uses: actions/setup-go@v4
       with:
         # Path to the go.mod or go.work file.
         go-version-file: go.mod
 
-    - name: Build
-      run: make
+    - name: Build ${{ matrix.arch }} binary
+      run: make build
+      env:
+        GOARCH: ${{ matrix.arch }}
+        GOARM: ${{ matrix.armver }}
 
-    - name: upload
+    - name: Rename ${{ matrix.arch }} binary
+      if: ${{ matrix.arch != 'arm' }}
+      run: mv bin/squid-exporter bin/squid-exporter-linux-${{ matrix.arch }}
+
+    - name: Rename ${{ matrix.arch }}v${{ matrix.armver }} binary
+      if: ${{matrix.arch == 'arm' }}
+      run: mv bin/squid-exporter bin/squid-exporter-linux-${{ matrix.arch }}v${{ matrix.armver }}
+
+    - name: Upload binary
       uses: actions/upload-artifact@master
       with:
         name: binary
-        path: bin/squid-exporter
+        path: bin/*
 
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
       run: mv bin/squid-exporter bin/squid-exporter-linux-${{ matrix.arch }}v${{ matrix.armver }}
 
     - name: Upload binary
-      uses: actions/upload-artifact@master
+      uses: actions/upload-artifact@v3
       with:
         name: binary
         path: bin/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,19 +10,17 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    continue-on-error: true
     strategy:
       fail-fast: false
       matrix:
-        arch_name: [386, amd64, armv6, armv7, arm64]
+        arch: [386, amd64, arm64]
         include:
-          - arch: ${{ matrix.arch_name }}
-          - arch_name: armv6
-            arch: arm
+          - arch: arm
             armver: 6
-          - arch_name: armv7
-            arch: arm
+          - arch: arm
             armver: 7
+    env:
+      arch_name: ${{ join([matrix.arch, matrix.armver], 'v' }}
 
     steps:
     - name: Checkout repository
@@ -34,14 +32,14 @@ jobs:
         # Path to the go.mod or go.work file.
         go-version-file: go.mod
 
-    - name: Build ${{ matrix.arch_name }} binary
+    - name: Build ${{ env.arch_name }} binary
       run: make build
       env:
         GOARCH: ${{ matrix.arch }}
         GOARM: ${{ matrix.armver }}
 
-    - name: Rename ${{ matrix.arch_name }} binary
-      run: mv bin/squid-exporter bin/squid-exporter-linux-${{ matrix.arch_name }}
+    - name: Rename ${{ env.arch_name }} binary
+      run: mv bin/squid-exporter bin/squid-exporter-linux-${{ env.arch_name }}
 
     - name: Upload binary
       uses: actions/upload-artifact@v3
@@ -69,6 +67,7 @@ jobs:
           overwrite: true
           body: "pre-release"
           prerelease: true
+
       - name: Release tag version
         if: startsWith(github.ref, 'refs/tags/v') 
         uses: svenstaro/upload-release-action@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
           - arch: arm
             armver: 7
     env:
-      arch_name: ${{ join([matrix.arch, matrix.armver], 'v' }}
+      arch_name: ${{ join((matrix.arch, matrix.armver), 'v' }}
 
     steps:
     - name: Checkout repository


### PR DESCRIPTION
This PR changes the release workflow to build binaries for linux for the architectures amd64(aka x86_64), 386(aka i386 or x86), arm64(aka aarch64), armv7, and armv6.
Instead of just amd64 like before.

I don't think that many people will want to use this on windows, but it shouldn't be too hard to add windows builds as well.
Just let me know if you want me to add them, or add them yourself, it shouldn't be that hard.