### PR TITLE
Build and publish docker image for multiple architectures

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    name: Build and publish
 
     steps:
     - name: Checkout repository
@@ -27,7 +28,7 @@ jobs:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
 
-    - name: Push the Docker image latest
+    - name: Build and publish Docker image
       uses: docker/build-push-action@v5
       with:
         context: .

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Login to DockerHub
       id: login
       uses: docker/login-action@v3
-      continue-on-error: true
+#      continue-on-error: true # Enable to test without docker hub credentials.
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -33,6 +33,6 @@ jobs:
         context: .
         push: ${{ steps.login.outcome == 'success' }}
         tags: ${{ secrets.DOCKER_USERNAME || 'local' }}/squid-exporter:latest,${{ startsWith(github.ref, 'refs/tags/v') && env.rev_tag || '' }}
-        platforms: linux/i386,linux/amd64,linux/arm64,linux/arm/v7
+        platforms: linux/amd64,linux/arm64,linux/arm/v7
       env:
         rev_tag: ${{ secrets.DOCKER_USERNAME }}/squid-exporter:${{ github.ref_name }} # Construct tag as env var to make tags line easier to read.

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -33,6 +33,6 @@ jobs:
         context: .
         push: ${{ steps.login.outcome == 'success' }}
         tags: ${{ secrets.DOCKER_USERNAME || 'local' }}/squid-exporter:latest,${{ startsWith(github.ref, 'refs/tags/v') && env.rev_tag || '' }}
-        platforms: linux/i386,linux/amd64,linux/arm64,linux/arm/v6,linux/arm/v7
+        platforms: linux/i386,linux/amd64,linux/arm64,linux/arm/v7
       env:
         rev_tag: ${{ secrets.DOCKER_USERNAME }}/squid-exporter:${{ github.ref_name }} # Construct tag as env var to make tags line easier to read.

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,35 +10,29 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
 
     - name: Login to DockerHub
-      uses: docker/login-action@v1
+      id: login
+      uses: docker/login-action@v3
+      continue-on-error: true
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
 
-    - name: Build the Docker image
-      run: docker build -t squid-exporter .
-
-    - name: Tag the Docker image latest
-      run: docker tag squid-exporter ${{ secrets.DOCKER_USERNAME }}/squid-exporter:latest
-
     - name: Push the Docker image latest
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v5
       with:
         context: .
-        push: true
-        tags: ${{ secrets.DOCKER_USERNAME }}/squid-exporter:latest
-
-    - name: Tag the Docker image version
-      if: startsWith(github.ref, 'refs/tags/v')
-      run: docker tag squid-exporter ${{ secrets.DOCKER_USERNAME }}/squid-exporter:${{ github.ref_name }}
-
-    - name: Push the Docker image latest
-      if: startsWith(github.ref, 'refs/tags/v')
-      uses: docker/build-push-action@v2
-      with:
-        context: .
-        push: true
-        tags: ${{ secrets.DOCKER_USERNAME }}/squid-exporter:${{ github.ref_name }}
+        push: ${{ steps.login.outcome == 'success' }}
+        tags: ${{ secrets.DOCKER_USERNAME }}/squid-exporter:latest,${{ startsWith(github.ref, 'refs/tags/v') && env.rev_tag }}
+        platforms: linux/i386,linux/amd64,linux/arm64,linux/arm/v6,linux/arm/v7
+      env:
+        rev_tag: ${{ secrets.DOCKER_USERNAME }}/squid-exporter:${{ github.ref_name }} # Construct tag as env var to make tags line easier to read.

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -32,7 +32,7 @@ jobs:
       with:
         context: .
         push: ${{ steps.login.outcome == 'success' }}
-        tags: ${{ secrets.DOCKER_USERNAME }}/squid-exporter:latest,${{ startsWith(github.ref, 'refs/tags/v') && env.rev_tag }}
+        tags: ${{ secrets.DOCKER_USERNAME || 'local' }}/squid-exporter:latest,${{ startsWith(github.ref, 'refs/tags/v') && env.rev_tag || '' }}
         platforms: linux/i386,linux/amd64,linux/arm64,linux/arm/v6,linux/arm/v7
       env:
         rev_tag: ${{ secrets.DOCKER_USERNAME }}/squid-exporter:${{ github.ref_name }} # Construct tag as env var to make tags line easier to read.


### PR DESCRIPTION
This PR changes the docker workflow to build the docker container for amd64, arm64, and armv7.
I would have liked to support i386 and armv6 as well, but since the distroless container doesn't support those there's nothing I could do without major changes to the project.

I haven't tested whether it works to give the image two tags like this, but I don't see any reason for that not working.

Fixes #69