### PR TITLE
chore: switch to scratch base image for multi-arch build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.git
+.github
+dashboards
+helm
+prometheus
+vendor
+Makefile
+Dockerfile

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,4 +1,4 @@
-name: Docker Image CI
+name: Build multi-arch docker images
 
 on:
   push:
@@ -11,7 +11,7 @@ jobs:
     name: Build and publish
 
     steps:
-    - name: Checkout repository
+    - name: Checkout
       uses: actions/checkout@v4
 
     - name: Set up QEMU
@@ -21,19 +21,23 @@ jobs:
       uses: docker/setup-buildx-action@v3
 
     - name: Login to DockerHub
-      id: login
       uses: docker/login-action@v3
-#      continue-on-error: true # Enable to test without docker hub credentials.
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
 
-    - name: Build and publish Docker image
+    - name: Docker meta
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: boynux/squid-exporter
+
+    - name: Build and push
       uses: docker/build-push-action@v5
       with:
-        context: .
-        push: ${{ steps.login.outcome == 'success' }}
-        tags: ${{ secrets.DOCKER_USERNAME || 'local' }}/squid-exporter:latest,${{ startsWith(github.ref, 'refs/tags/v') && env.rev_tag || '' }}
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
         platforms: linux/amd64,linux/arm64,linux/arm/v7
-      env:
-        rev_tag: ${{ secrets.DOCKER_USERNAME }}/squid-exporter:${{ github.ref_name }} # Construct tag as env var to make tags line easier to read.
+        pull: true
+        push: true
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,30 @@
-FROM golang:alpine as builder
+FROM golang:1.19.1-alpine as build
 
-WORKDIR /go/src/github.com/boynux/squid-exporter
+ARG TARGETPLATFORM
+RUN echo "Building for ${TARGETPLATFORM}"
+
+WORKDIR /go/src
+
+COPY go.mod go.sum ./
+RUN go mod download
+
 COPY . .
 
-# Compile the binary statically, so it can be run without libraries.
-RUN CGO_ENABLED=0 GOOS=linux go install -a -ldflags '-extldflags "-s -w -static"' .
+RUN CGO_ENABLED=0 go build -a -ldflags '-extldflags "-s -w -static"' -o /squid-exporter .
 
-FROM gcr.io/distroless/static:nonroot
-COPY --from=builder /go/bin/squid-exporter /usr/local/bin/squid-exporter
 
-# Allow /etc/hosts to be used for DNS
-COPY --from=builder /etc/nsswitch.conf /etc/nsswitch.conf
+FROM scratch as final
+
+LABEL org.opencontainers.image.title="Squid Exporter"
+LABEL org.opencontainers.image.description="This is a Docker image for Squid Prometheus Exporter."
+LABEL org.opencontainers.image.source="https://github.com/boynux/squid-exporter/"
+LABEL org.opencontainers.image.licenses="MIT"
+
+ENV SQUID_EXPORTER_LISTEN="0.0.0.0:9301"
+
+COPY --from=build /squid-exporter /squid-exporter
 
 EXPOSE 9301
 
-ENTRYPOINT ["/usr/local/bin/squid-exporter"]
+ENTRYPOINT ["/squid-exporter"]
+


### PR DESCRIPTION
Add .dockerignore to speeed up the build
Use of docker meta data action to generate docker tags and labels