### PR TITLE
Fix various golangci-lint nags

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,18 @@
+linters:
+  enable:
+    - errorlint
+    - goimports
+    - misspell
+    - perfsprint
+    - testifylint
+    - usestdlibvars
+
+issues:
+  exclude-rules:
+    - path: _test.go
+      linters:
+        - errcheck
+
+linters-settings:
+  goimports:
+    local-prefixes: github.com/boynux/squid-exporter

--- a/collector/client_test.go
+++ b/collector/client_test.go
@@ -4,8 +4,10 @@ import (
 	"net"
 	"testing"
 
-	"github.com/boynux/squid-exporter/types"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/boynux/squid-exporter/types"
 )
 
 type mockConnectionHandler struct {
@@ -74,7 +76,7 @@ func TestDecodeMetricStrings(t *testing.T) {
 		c, err := tc.d(tc.s)
 
 		if tc.e != "" {
-			assert.EqualError(t, err, tc.e)
+			require.EqualError(t, err, tc.e)
 		}
 		assert.Equal(t, tc.c, c)
 	}

--- a/collector/metrics.go
+++ b/collector/metrics.go
@@ -4,8 +4,9 @@ import (
 	"log"
 	"time"
 
-	"github.com/boynux/squid-exporter/config"
 	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/boynux/squid-exporter/config"
 )
 
 type descMap map[string]*prometheus.Desc
@@ -22,7 +23,7 @@ var (
 	infos               descMap
 )
 
-/*Exporter entry point to squid exporter */
+// Exporter entry point to Squid exporter.
 type Exporter struct {
 	client SquidClient
 
@@ -42,7 +43,7 @@ type CollectorConfig struct {
 	Headers  []string
 }
 
-/*New initializes a new exporter */
+// New initializes a new exporter.
 func New(c *CollectorConfig) *Exporter {
 	counters = generateSquidCounters(c.Labels.Keys)
 	if ExtractServiceTimes {
@@ -90,10 +91,9 @@ func (e *Exporter) Describe(ch chan<- *prometheus.Desc) {
 	for _, v := range infos {
 		ch <- v
 	}
-
 }
 
-/*Collect fetches metrics from squid manager and pushes them to promethus */
+// Collect fetches metrics from Squid manager and expose them to Prometheus.
 func (e *Exporter) Collect(c chan<- prometheus.Metric) {
 	insts, err := e.client.GetCounters()
 

--- a/collector/service_times.go
+++ b/collector/service_times.go
@@ -119,8 +119,7 @@ func generateSquidServiceTimes(labels []string) descMap {
 	for i := range squidServiceTimess {
 		serviceTime := squidServiceTimess[i]
 
-		var key string
-		var name string
+		var key, name string
 
 		if serviceTime.Counter != "" {
 			key = fmt.Sprintf("%s_%s_%s", serviceTime.Section, serviceTime.Counter, serviceTime.Suffix)
@@ -129,7 +128,7 @@ func generateSquidServiceTimes(labels []string) descMap {
 		} else {
 			key = fmt.Sprintf("%s_%s", serviceTime.Section, serviceTime.Suffix)
 			name = prometheus.BuildFQName(namespace, strings.Replace(serviceTime.Section, ".", "_", -1),
-				fmt.Sprintf("%s", serviceTime.Suffix))
+				serviceTime.Suffix)
 		}
 
 		serviceTimes[key] = prometheus.NewDesc(

--- a/config/config.go
+++ b/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"log"
@@ -42,7 +43,7 @@ type Labels struct {
 	Values []string
 }
 
-/*Config configurations for exporter */
+// Config configurations for exporter.
 type Config struct {
 	ListenAddress       string
 	WebConfigPath       string
@@ -59,7 +60,7 @@ type Config struct {
 	UseProxyHeader bool
 }
 
-/*NewConfig creates a new config object from command line args */
+// NewConfig creates a new config object from command line args.
 func NewConfig() *Config {
 	c := &Config{}
 
@@ -146,12 +147,12 @@ func (l *Labels) Set(value string) error {
 	args := strings.Split(value, "=")
 
 	if len(args) != 2 || len(args[1]) < 1 {
-		return fmt.Errorf("Label must be in 'key=value' format")
+		return errors.New("label must be in 'key=value' format")
 	}
 
 	for _, key := range l.Keys {
 		if key == args[0] {
-			return fmt.Errorf("Labels must be distinct, found duplicated key %s", args[0])
+			return fmt.Errorf("labels must be distinct; found duplicate key %q", args[0])
 		}
 	}
 	l.Keys = append(l.Keys, args[0])

--- a/helpers.go
+++ b/helpers.go
@@ -6,9 +6,9 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/boynux/squid-exporter/config"
-
 	proxyproto "github.com/pires/go-proxyproto"
+
+	"github.com/boynux/squid-exporter/config"
 )
 
 func createProxyHeader(cfg *config.Config) string {

--- a/main.go
+++ b/main.go
@@ -8,8 +8,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/boynux/squid-exporter/collector"
-	"github.com/boynux/squid-exporter/config"
 	kitlog "github.com/go-kit/log"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
@@ -17,6 +15,9 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/prometheus/common/version"
 	"github.com/prometheus/exporter-toolkit/web"
+
+	"github.com/boynux/squid-exporter/collector"
+	"github.com/boynux/squid-exporter/config"
 )
 
 func init() {
@@ -53,11 +54,11 @@ func main() {
 			PidFn: func() (int, error) {
 				content, err := os.ReadFile(cfg.Pidfile)
 				if err != nil {
-					return 0, fmt.Errorf("can't read pid file %q: %s", cfg.Pidfile, err)
+					return 0, fmt.Errorf("cannot read pid file %q: %w", cfg.Pidfile, err)
 				}
 				value, err := strconv.Atoi(strings.TrimSpace(string(content)))
 				if err != nil {
-					return 0, fmt.Errorf("can't parse pid file %q: %s", cfg.Pidfile, err)
+					return 0, fmt.Errorf("cannot parse pid file %q: %w", cfg.Pidfile, err)
 				}
 				return value, nil
 			},

--- a/types/types.go
+++ b/types/types.go
@@ -1,17 +1,17 @@
 package types
 
-/*VarLabel maps key value prometheus labes*/
+// VarLabel maps key value Prometheus labels.
 type VarLabel struct {
 	Key   string
 	Value string
 }
 
-/*Counter maps a squid conters */
+// Counter maps a Squid counter.
 type Counter struct {
 	Key       string
 	Value     float64
 	VarLabels []VarLabel
 }
 
-/*Counters is a list of multiple squid counters */
+// Counters is a list of multiple Squid counters.
 type Counters []Counter


### PR DESCRIPTION
Add a minimal .golangci.yml config and address the most obvious lint warnings.