### PR TITLE
Simplify get

### DIFF
--- a/collector/client_test.go
+++ b/collector/client_test.go
@@ -46,9 +46,11 @@ func TestReadFromSquid(t *testing.T) {
 	coc := &CacheObjectClient{
 		ch,
 		"",
-		[]string{},
+		"",
 	}
-	expected := "GET cache_object://localhost/test HTTP/1.0\r\nHost: localhost\r\nUser-Agent: squidclient/3.5.12\r\nAccept: */*\r\n\r\n"
+	// This test is overly brittle; the order of HTTP headers is not significant. Go sorts headers
+	// lexicographically when calling http.Header.Write().
+	expected := "GET cache_object://localhost/test HTTP/1.0\r\nAccept: */*\r\nHost: localhost\r\nUser-Agent: squidclient/3.5.12\r\n\r\n"
 	coc.readFromSquid("test")
 
 	assert.Equal(t, expected, string(ch.buffer))

--- a/collector/metrics.go
+++ b/collector/metrics.go
@@ -34,12 +34,12 @@ type Exporter struct {
 }
 
 type CollectorConfig struct {
-	Hostname string
-	Port     int
-	Login    string
-	Password string
-	Labels   config.Labels
-	Headers  []string
+	Hostname    string
+	Port        int
+	Login       string
+	Password    string
+	Labels      config.Labels
+	ProxyHeader string
 }
 
 /*New initializes a new exporter */
@@ -57,7 +57,7 @@ func New(c *CollectorConfig) *Exporter {
 			c.Port,
 			c.Login,
 			c.Password,
-			c.Headers,
+			c.ProxyHeader,
 		}),
 
 		c.Hostname,

--- a/main.go
+++ b/main.go
@@ -31,20 +31,20 @@ func main() {
 	}
 	collector.ExtractServiceTimes = cfg.ExtractServiceTimes
 
-	headers := []string{}
+	proxyHeader := ""
 
 	if cfg.UseProxyHeader {
-		headers = append(headers, createProxyHeader(cfg))
+		proxyHeader = createProxyHeader(cfg)
 	}
 
 	log.Println("Scraping metrics from", fmt.Sprintf("%s:%d", cfg.SquidHostname, cfg.SquidPort))
 	e := collector.New(&collector.CollectorConfig{
-		Hostname: cfg.SquidHostname,
-		Port:     cfg.SquidPort,
-		Login:    cfg.Login,
-		Password: cfg.Password,
-		Labels:   cfg.Labels,
-		Headers:  headers,
+		Hostname:    cfg.SquidHostname,
+		Port:        cfg.SquidPort,
+		Login:       cfg.Login,
+		Password:    cfg.Password,
+		Labels:      cfg.Labels,
+		ProxyHeader: proxyHeader,
 	})
 	prometheus.MustRegister(e)
 


### PR DESCRIPTION
Refactor and simplify the `get()` function, using some built-in types like `http.Header` to make the code clearer. Also check for errors when writing to `net.Conn`.

Change `Headers` string slice in struct members to a `ProxyHeader` string. This is only ever used for an optional PROXY protocol header, and was easy to confuse with HTTP headers.