### PR TITLE
Drop cache_mgr URI support, add squid-internal-mgr support

### DIFF
--- a/collector/metrics.go
+++ b/collector/metrics.go
@@ -53,13 +53,7 @@ func New(c *CollectorConfig) *Exporter {
 	infos = generateSquidInfos(c.Labels.Keys)
 
 	return &Exporter{
-		NewCacheObjectClient(&CacheObjectRequest{
-			c.Hostname,
-			c.Port,
-			c.Login,
-			c.Password,
-			c.ProxyHeader,
-		}),
+		NewCacheObjectClient(c.Hostname, c.Port, c.Login, c.Password, c.ProxyHeader),
 
 		c.Hostname,
 		c.Port,


### PR DESCRIPTION
Drop obsolete `cache_mgr://` URI support, which will be removed in Squid 7. Implement support for `squid-internal-mgr` endpoint support via HTTP(S).

Fixes: #100
Obsoletes: #99