### PR TITLE
Do not log to global logger from inside createProxyHeader function

### DIFF
--- a/helpers_test.go
+++ b/helpers_test.go
@@ -4,11 +4,12 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/boynux/squid-exporter/config"
 )
 
-func TestCreatProxyHelper(t *testing.T) {
+func TestCreateProxyHelper(t *testing.T) {
 	cfg := &config.Config{
 		ListenAddress: "192.0.2.1:3192",
 		SquidHostname: "127.0.0.1",
@@ -17,6 +18,7 @@ func TestCreatProxyHelper(t *testing.T) {
 
 	expectedHProxyString := "PROXY TCP4 192.0.2.1 127.0.0.1 3192 3128"
 
-	p := createProxyHeader(cfg)
+	p, err := createProxyHeader(cfg)
+	require.NoError(t, err)
 	assert.Equal(t, expectedHProxyString, p, "Proxy headers do not match!")
 }

--- a/main.go
+++ b/main.go
@@ -35,7 +35,10 @@ func main() {
 	proxyHeader := ""
 
 	if cfg.UseProxyHeader {
-		proxyHeader = createProxyHeader(cfg)
+		var err error
+		if proxyHeader, err = createProxyHeader(cfg); err != nil {
+			log.Println("Could not create proxy header: ", err)
+		}
 	}
 
 	log.Println("Scraping metrics from", fmt.Sprintf("%s:%d", cfg.SquidHostname, cfg.SquidPort))


### PR DESCRIPTION
Logging to a global logger from within a function makes the code unportable if / when logging frameworks are swapped out. It is more elegant to return errors (possibly with wrapped errors within), and allow the caller to decide how (or even if) to log the error.

This lays the foundations for migrating logging to use the Go standard library `log/slog`, which is required for later versions of exporter-toolkit.